### PR TITLE
Reverts changes to *meow, *mrrp

### DIFF
--- a/modular_splurt/code/modules/mob/living/emotes.dm
+++ b/modular_splurt/code/modules/mob/living/emotes.dm
@@ -1440,16 +1440,9 @@
 
 /datum/emote/living/audio/meow
 	key = "meow"
-	key_third_person = "mrowls"
-	message = "mrowls!"
-	emote_sound = 'modular_citadel/sound/voice/meow1.ogg'
-	emote_cooldown = 0.6 SECONDS
-	emote_pitch_variance = FALSE
-
-/datum/emote/living/audio/meow2
-	key = "meow2"
 	key_third_person = "meows"
 	message = "meows!"
+	message_mime = "meows silently!"
 	emote_sound = 'modular_splurt/sound/voice/catpeople/cat_meow1.ogg'
 	emote_cooldown = 0.8 SECONDS // the longest audio is 1 second but who gives a fuck mrrp mrrp meow
 	emote_pitch_variance = FALSE // why would you
@@ -1458,10 +1451,11 @@
 	emote_sound = pick('modular_splurt/sound/voice/catpeople/cat_meow1.ogg', 'modular_splurt/sound/voice/catpeople/cat_meow2.ogg', 'modular_splurt/sound/voice/catpeople/cat_meow3.ogg') // Credit to Nyanotrasen (https://github.com/Nyanotrasen/Nyanotrasen)
 	. = ..()
 
-/datum/emote/living/audio/meow3
-	key = "meow3"
+/datum/emote/living/audio/meow2
+	key = "meow2"
 	key_third_person = "mews!"
 	message = "mews!"
+	message_mime = "mews silently!"
 	emote_sound = 'modular_splurt/sound/voice/catpeople/cat_mew1.ogg'
 	emote_cooldown = 0.8 SECONDS // mrrp mrrp meow
 	emote_pitch_variance = FALSE
@@ -1470,28 +1464,25 @@
 	emote_sound = pick('modular_splurt/sound/voice/catpeople/cat_mew1.ogg', 'modular_splurt/sound/voice/catpeople/cat_mew2.ogg') // Credit to Nyanotrasen (https://github.com/Nyanotrasen/Nyanotrasen)
 	. = ..()
 
+/datum/emote/living/audio/mrrp
+	key = "mrrp"
+	key_third_person = "mrrps"
+	message = "trills like a cat!"
+	message_mime = "trills silently!"
+	emote_sound = 'modular_splurt/sound/voice/catpeople/cat_mrrp1.ogg'
+	emote_cooldown = 0.8 SECONDS // mrrp mrrp meow
+	emote_pitch_variance = FALSE
+
+/datum/emote/living/audio/mrrp/run_emote(mob/user, params)
+	emote_sound = pick('modular_splurt/sound/voice/catpeople/cat_mrrp1.ogg', 'modular_splurt/sound/voice/catpeople/cat_mrrp2.ogg')
+	. = ..()
+
 /datum/emote/living/audio/mrowl
 	key = "mrowl"
 	key_third_person = "mrowls"
 	message = "mrowls."
 	emote_sound = 'modular_splurt/sound/voice/mrowl.ogg'
 	emote_cooldown = 0.95 SECONDS
-	emote_pitch_variance = FALSE
-
-/datum/emote/living/audio/mrrp
-	key = "mrrp"
-	key_third_person = "mrrps"
-	message = "trills like a cat!"
-	emote_sound = 'modular_splurt/sound/voice/catpeople/cat_mrrp1.ogg'
-	emote_cooldown = 0.8 SECONDS // mrrp mrrp meow
-	emote_pitch_variance = FALSE
-
-/datum/emote/living/audio/mrrp2
-	key = "mrrp2"
-	key_third_person = "mrrps"
-	message = "trills like a cat!"
-	emote_sound = 'modular_splurt/sound/voice/catpeople/cat_mrrp2.ogg'
-	emote_cooldown = 0.8 SECONDS
 	emote_pitch_variance = FALSE
 
 /datum/emote/living/audio/gay


### PR DESCRIPTION
# About The Pull Request

SPLURT Maintainers tried to revert my changes to *meow and didn't understand how the code worked, they simply changed the first instance emote_sound is called, but did not change the one where it selects emote_sound at random, then created a clone emote called *meow2 which does the same thing as *meow. 

Another commit aimed to separate *mrrp into a second *mrrp2, however both emotes play the same sound file.

This is cluttercode, SPLURT maintainers do not test their code before creating PRs.

## Why It's Good For The Game

Cleans up code, removes broken emotes, makes the emote list smaller.

## A Port?

Yes, sound files pulled from Nyanotrasen. https://github.com/Nyanotrasen/Nyanotrasen Thank you Rayne.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
fix: Fixed cluttercode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
