### PR TITLE
silicons can now use the emote panel

### DIFF
--- a/code/modules/mob/living/carbon/emote.dm
+++ b/code/modules/mob/living/carbon/emote.dm
@@ -13,7 +13,7 @@
 	name = "blink rapidly"
 	message = "blinks rapidly."
 
-/datum/emote/living/carbon/clap
+/datum/emote/sound/human/clap
 	key = "clap"
 	key_third_person = "claps"
 	message = "claps."
@@ -21,18 +21,9 @@
 	restraint_check = TRUE
 	emote_type = EMOTE_AUDIBLE
 
-/datum/emote/living/carbon/clap/run_emote(mob/living/user, params)
+/datum/emote/sound/human/clap/run_emote(mob/user, params)
+	sound = pick('sound/misc/clap1.ogg', 'sound/misc/clap2.ogg', 'sound/misc/clap3.ogg', 'sound/misc/clap4.ogg')
 	. = ..()
-	if (.)
-		if (ishuman(user))
-			// Need hands to clap
-			if (!user.get_bodypart(BODY_ZONE_L_ARM) || !user.get_bodypart(BODY_ZONE_R_ARM))
-				return
-			var/clap = pick('sound/misc/clap1.ogg',
-							'sound/misc/clap2.ogg',
-							'sound/misc/clap3.ogg',
-							'sound/misc/clap4.ogg')
-			playsound(user, clap, 50, 1, -1)
 
 /datum/emote/living/carbon/gnarl
 	key = "gnarl"

--- a/code/modules/mob/living/carbon/human/emote.dm
+++ b/code/modules/mob/living/carbon/human/emote.dm
@@ -162,7 +162,7 @@
 		T.Entered(src)
 
 /datum/emote/sound/human
-	mob_type_allowed_typecache = list(/mob/living/carbon/human)
+	mob_type_allowed_typecache = list(/mob/living/) // /sound/human/ became the global emote type, so this is now the only valid typecache
 	emote_type = EMOTE_AUDIBLE
 
 /datum/emote/sound/human/buzz

--- a/modular_citadel/code/modules/mob/cit_emotes.dm
+++ b/modular_citadel/code/modules/mob/cit_emotes.dm
@@ -220,7 +220,8 @@
 
 /datum/emote/sound/human/clap1
 	key = "clap1"
-	key_third_person = "claps"
+	key_third_person = "clap1s"
+	name = "clap once"
 	message = "claps their hands together."
 	emote_type = EMOTE_AUDIBLE
 	muzzle_ignore = TRUE


### PR DESCRIPTION
<!-- FILLING OUT THIS FORM PROPERLY AND ADDING A PROPER CHANGELOG SECTION IS **NECESSARY** FOR PULL REQUESTS. IF THE INFORMATION IS NOT PROVIDED YOUR PR WILL NOT BE CONSIDERED FOR MERGING -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

# About The Pull Request
Fixes some bugs brought about by the emote code refactor.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
<!-- If your PR is related to one of our discord suggestions, please add the number of this suggestion to this section. Or if you may, the message link of said suggestion-->

## Why It's Good For The Game
See above.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## A Port?
No.
<!-- Just say if it is a port of something and link the original pr/commit/whatever. -->

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
fix: fixes bugs brought about by the emote panel
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
