### PR TITLE
Ports chemical press safety feature from TG

### DIFF
--- a/code/modules/plumbing/plumbers/pill_press.dm
+++ b/code/modules/plumbing/plumbers/pill_press.dm
@@ -62,6 +62,10 @@
 
 	AddComponent(/datum/component/plumbing/simple_demand, bolt, layer)
 
+/obj/machinery/plumbing/pill_press/Destroy()
+	QDEL_LAZYLIST(stored_products)
+	return ..()
+
 /obj/machinery/plumbing/pill_press/examine(mob/user)
 	. = ..()
 	. += span_notice("The [name] currently has [stored_products.len] stored. There needs to be less than [MAX_FLOOR_PRODUCTS] on the floor to continue dispensing.")


### PR DESCRIPTION
## About The Pull Request
Ports chemical press deleting pills on deletion from TG so people dont crash and die

From: 
https://github.com/tgstation/tgstation/pull/88002

## Why It's Good For The Game
Previously if you deconstructed a chemical press with pills inside it would drop all the pills on the floor, all 3772 of them and then crash people around said tile lagging the fuck out of the server
![image](https://github.com/user-attachments/assets/7340320c-d30b-496f-adeb-e1e21290fb85)
Now it doesnt
## Proof Of Testing

<details>
<summary>Screenshots/Videos</summary>

![image](https://github.com/user-attachments/assets/944dc920-8fba-4076-bab0-7ce0ee356a69)

</details>

## Changelog
:cl:
qol: pills from the chemical press now delete upon deconstruction
/:cl:
