### PR TITLE
Re-enable big slappy and materials market imports

### DIFF
--- a/code/modules/cargo/packs/imports.dm
+++ b/code/modules/cargo/packs/imports.dm
@@ -301,6 +301,9 @@
 	contains = list(/obj/item/reagent_containers/cup/glass/bottle/juice/dreadnog = 3)
 	crate_name = "dreadnog crate"
 
+// VENUS EDIT: RE-ENABLED Start
+// BUBBER EDIT - Removal Start
+
 /datum/supply_pack/imports/giant_wrench_parts
 	name = "Big Slappy parts"
 	desc = "Illegal Big Slappy parts. The fastest and statistically most dangerous wrench."
@@ -309,7 +312,7 @@
 	contains = list(/obj/item/weaponcrafting/giant_wrench)
 	crate_name = "unknown parts crate"
 
-/datum/supply_pack/imports/materials_market
+/datum/supply_pack/imports/materials_market //RE ENABLE IF FIXED UPSTREAM
 	name = "Galactic Materials Market Crate"
 	desc = "A circuit board to build your own materials market for use by certified market traders. Warning: Losses are not covered by insurance."
 	cost = CARGO_CRATE_VALUE * 3
@@ -322,6 +325,9 @@
 	)
 	crate_name = "materials market crate"
 	crate_type = /obj/structure/closet/crate/cargo
+
+// BUBBER EDIT - Removal End
+// VENUS EDIT: RE-ENABLED End
 
 /datum/supply_pack/imports/floortilecamo
 	name = "Floor-tile Camouflage Uniform"

--- a/code/modules/cargo/packs/imports.dm
+++ b/code/modules/cargo/packs/imports.dm
@@ -301,7 +301,6 @@
 	contains = list(/obj/item/reagent_containers/cup/glass/bottle/juice/dreadnog = 3)
 	crate_name = "dreadnog crate"
 
-/* BUBBER EDIT - Removal Start
 /datum/supply_pack/imports/giant_wrench_parts
 	name = "Big Slappy parts"
 	desc = "Illegal Big Slappy parts. The fastest and statistically most dangerous wrench."
@@ -310,7 +309,7 @@
 	contains = list(/obj/item/weaponcrafting/giant_wrench)
 	crate_name = "unknown parts crate"
 
-/datum/supply_pack/imports/materials_market - RENABLE IF FIXED UPSTREAM
+/datum/supply_pack/imports/materials_market
 	name = "Galactic Materials Market Crate"
 	desc = "A circuit board to build your own materials market for use by certified market traders. Warning: Losses are not covered by insurance."
 	cost = CARGO_CRATE_VALUE * 3
@@ -323,7 +322,6 @@
 	)
 	crate_name = "materials market crate"
 	crate_type = /obj/structure/closet/crate/cargo
-Removal End */
 
 /datum/supply_pack/imports/floortilecamo
 	name = "Floor-tile Camouflage Uniform"


### PR DESCRIPTION
Re-enables few imports for cargo console
## About The Pull Request

Big slappy parts and materials market crate are back in cargo console

## Why It's Good For The Game

Returning of old way to get money and materials through market and of course cargo favourite giant shovel.

## Quick note
 
No ports were made and it was tested before i made this pr.

## Changelog

Re-enabling materials market and big slappy parts imports in cargo console






