### PR TITLE
Makes TRAIT_BIMBO Not Lethal

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -53,19 +53,21 @@
 	//the message that will be sent to the owner at the end
 	var/lust_message = "Your breath begins to feel warm..."
 	//we are using if statements so that it slowly becomes more and more to the person
+	//VENUS EDIT START
 	human_owner.manual_emote(pick(lust_emotes))
 	if(stress >= 60)
-		lust_message = "You feel a static sensation all across your skin..."
+		lust_message = "You feel a static sensation all across your skin..." //VENUS EDIT: Removed jitter
 	if(stress >= 120)
-		lust_message = "You feel a heat beginning to rise..."
+		lust_message = "You feel a heat beginning to rise..." //VENUS EDIT: Removed eye blur
 	if(stress >= 180)
-		lust_message = "You begin to fantasize of what you could do to someone..."
+		lust_message = "You begin to fantasize of what you could do to someone..." //VENUS EDIT: Removes hallucinations
 	if(stress >= 240)
-		human_owner.adjustStaminaLoss(30)
+		human_owner.adjustStaminaLoss(30) //VENUS COMMENT: Bimbos can be vulnerable, as a treat
 		lust_message = "You body feels so very hot, almost unwilling to cooperate..."
 	if(stress >= 300)
-		owner.losebreath += 1 //suffocation
+		owner.losebreath += 1 ////VENUS EDIT: Adjusts suffocation
 		lust_message = "You feel your neck tightening, straining..."
+	//VENUS EDIT END
 	to_chat(human_owner, span_purple(lust_message))
 	return TRUE
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -55,20 +55,17 @@
 	//we are using if statements so that it slowly becomes more and more to the person
 	human_owner.manual_emote(pick(lust_emotes))
 	if(stress >= 60)
-		human_owner.set_jitter_if_lower(40 SECONDS)
 		lust_message = "You feel a static sensation all across your skin..."
 	if(stress >= 120)
-		human_owner.set_eye_blur_if_lower(20 SECONDS)
 		lust_message = "You vision begins to blur, the heat beginning to rise..."
 	if(stress >= 180)
-		owner.adjust_hallucinations(60 SECONDS)
 		lust_message = "You begin to fantasize of what you could do to someone..."
 	if(stress >= 240)
 		human_owner.adjustStaminaLoss(30)
 		lust_message = "You body feels so very hot, almost unwilling to cooperate..."
-	if(stress >= 300)
-		human_owner.adjustOxyLoss(40)
-		lust_message = "You feel your neck tightening, straining..."
+    if(stress >= 300)
+        owner.losebreath += 1 //suffocation
+        lust_message = "You feel your neck tightening, straining..."
 	to_chat(human_owner, span_purple(lust_message))
 	return TRUE
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -66,7 +66,7 @@
 		lust_message = "You begin to fantasize of what you could do to someone..." //VENUS EDIT: Removes hallucinations
 	if(stress >= 240)
 		human_owner.adjustStaminaLoss(30) //VENUS COMMENT: Bimbos can be vulnerable, as a treat
-		lust_message = "You body feels so very hot, almost unwilling to cooperate..."
+		lust_message = "Your body feels so very hot, almost unwilling to cooperate..."
 	if(stress >= 300)
 		owner.losebreath += 1 ////VENUS EDIT: Adjusts suffocation
 		//human_owner.adjustOxyLoss(40)

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -53,7 +53,6 @@
 	//the message that will be sent to the owner at the end
 	var/lust_message = "Your breath begins to feel warm..."
 	//we are using if statements so that it slowly becomes more and more to the person
-++
 	human_owner.manual_emote(pick(lust_emotes))
 	if(stress >= 60)
 		//human_owner.set_jitter_if_lower(40 SECONDS) VENUS REMOVAL

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -63,9 +63,9 @@
 	if(stress >= 240)
 		human_owner.adjustStaminaLoss(30)
 		lust_message = "You body feels so very hot, almost unwilling to cooperate..."
-    if(stress >= 300)
-        owner.losebreath += 1 //suffocation
-        lust_message = "You feel your neck tightening, straining..."
+	if(stress >= 300)
+	owner.losebreath += 1 //suffocation
+	lust_message = "You feel your neck tightening, straining..."
 	to_chat(human_owner, span_purple(lust_message))
 	return TRUE
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -53,25 +53,24 @@
 	//the message that will be sent to the owner at the end
 	var/lust_message = "Your breath begins to feel warm..."
 	//we are using if statements so that it slowly becomes more and more to the person
-	//VENUS EDIT START
+++
 	human_owner.manual_emote(pick(lust_emotes))
 	if(stress >= 60)
-		//human_owner.set_jitter_if_lower(40 SECONDS)
-		lust_message = "You feel a static sensation all across your skin..." //VENUS EDIT: Removed jitter
+		//human_owner.set_jitter_if_lower(40 SECONDS) VENUS REMOVAL
+		lust_message = "You feel a static sensation all across your skin..."
 	if(stress >= 120)
 		//human_owner.set_eye_blur_if_lower(20 SECONDS)
-		lust_message = "You feel a heat beginning to rise..." //VENUS EDIT: Removed eye blur
+		lust_message = "You feel the heat beginning to rise..." //VENUS EDIT - Original: "You vision begins to blur, the heat beginning to rise..."
 	if(stress >= 180)
-		//owner.adjust_hallucinations(60 SECONDS)
-		lust_message = "You begin to fantasize of what you could do to someone..." //VENUS EDIT: Removes hallucinations
+		//owner.adjust_hallucinations(60 SECONDS) VENUS REMOVAL
+		lust_message = "You begin to fantasize of what you could do to someone..."
 	if(stress >= 240)
-		human_owner.adjustStaminaLoss(30) //VENUS COMMENT: Bimbos can be vulnerable, as a treat
-		lust_message = "Your body feels so very hot, almost unwilling to cooperate..."
+		human_owner.adjustStaminaLoss(30)
+		lust_message = "Your body feels very hot, almost unwilling to cooperate..." //VENUS EDIT - Original: "You body feels so very hot, almost unwilling to cooperate..."
 	if(stress >= 300)
-		owner.losebreath += 1 ////VENUS EDIT: Adjusts suffocation
-		//human_owner.adjustOxyLoss(40)
+		owner.losebreath += 1//VENUS ADDITION: Added suffocation
+		//human_owner.adjustOxyLoss(40) VENUS REMOVAL
 		lust_message = "You feel your neck tightening, straining..."
-	//VENUS EDIT END
 	to_chat(human_owner, span_purple(lust_message))
 	return TRUE
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -57,15 +57,15 @@
 	if(stress >= 60)
 		lust_message = "You feel a static sensation all across your skin..."
 	if(stress >= 120)
-		lust_message = "You vision begins to blur, the heat beginning to rise..."
+		lust_message = "You feel a heat beginning to rise..."
 	if(stress >= 180)
 		lust_message = "You begin to fantasize of what you could do to someone..."
 	if(stress >= 240)
 		human_owner.adjustStaminaLoss(30)
 		lust_message = "You body feels so very hot, almost unwilling to cooperate..."
 	if(stress >= 300)
-	owner.losebreath += 1 //suffocation
-	lust_message = "You feel your neck tightening, straining..."
+		owner.losebreath += 1 //suffocation
+		lust_message = "You feel your neck tightening, straining..."
 	to_chat(human_owner, span_purple(lust_message))
 	return TRUE
 

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -56,16 +56,20 @@
 	//VENUS EDIT START
 	human_owner.manual_emote(pick(lust_emotes))
 	if(stress >= 60)
+		//human_owner.set_jitter_if_lower(40 SECONDS)
 		lust_message = "You feel a static sensation all across your skin..." //VENUS EDIT: Removed jitter
 	if(stress >= 120)
+		//human_owner.set_eye_blur_if_lower(20 SECONDS)
 		lust_message = "You feel a heat beginning to rise..." //VENUS EDIT: Removed eye blur
 	if(stress >= 180)
+		//owner.adjust_hallucinations(60 SECONDS)
 		lust_message = "You begin to fantasize of what you could do to someone..." //VENUS EDIT: Removes hallucinations
 	if(stress >= 240)
 		human_owner.adjustStaminaLoss(30) //VENUS COMMENT: Bimbos can be vulnerable, as a treat
 		lust_message = "You body feels so very hot, almost unwilling to cooperate..."
 	if(stress >= 300)
 		owner.losebreath += 1 ////VENUS EDIT: Adjusts suffocation
+		//human_owner.adjustOxyLoss(40)
 		lust_message = "You feel your neck tightening, straining..."
 	//VENUS EDIT END
 	to_chat(human_owner, span_purple(lust_message))


### PR DESCRIPTION

## About The Pull Request
The bimbo trait (TRAIT_BIMBO) applies 40 oxygen damage to the owner of the trait. This is incredibly lethal. Above 50 oxygen damage the owner of the trait will fall unconscious, once oxygen damage reaches 100 they are in critical condition and oxygen damage will not heal.

The trait is meant to cause "loss of breath", not 40 damage. In comparison, cyanide also causes loss of breath by stopping respiration. Being a bimbo is more lethal than cyanide.

This PR replaces the 40 oxygen damage with something similar to cyanide, a bimbo will cease respiration for a few moments to catch their breath if they don't have sex for awhile. This PR also removed hallucinations, blurry vision, and fixes a grammatical error. 

Bimbos still suffer stamina damage if they don't have enough sex.

TL;DR this makes being a bimbo not kill people.

Cope PR, I made someone into a bimbo and they died.
## Why It's Good For The Game
Makes bimboification not lethal. Encourages more people to engage with bimboification mechanics. 
Also, this code was written three years ago, it's about time it got a little change.
## Changelog
:cl:
balance: Bimbos no longer suffer lethal oxygen damage, instead they need to catch their breath. 
/:cl:
