### PR TITLE
Bimbo Update: Vulnerability

### DIFF
--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -33,13 +33,14 @@
 	///The time between each desire message within company
 	var/desire_cooldown_number = 30 SECONDS
 	///The list of manual emotes that will be done when unsatisfied
-	var/static/list/lust_emotes = list(
-		"pants as their body trembles lightly.",
-		"lightly touches themselves up and down, feeling every inch.",
-		"puts their finger in their mouth and slightly bites down.",
-		"places their hands on their hip as they slowly gyrate.",
-		"moans, their head tilted slightly."
-	)
+	//var/static/list/lust_emotes = list( VENUS REMOVAL: Removes emote spam
+		//"pants as their body trembles lightly.", VENUS REMOVAL
+		//"lightly touches themselves up and down, feeling every inch.", VENUS REMOVAL
+		//"puts their finger in their mouth and slightly bites down.", VENUS REMOVAL
+		//"places their hands on their hip as they slowly gyrate.", VENUS REMOVAL
+		//"moans, their head tilted slightly." VENUS REMOVAL
+	//) VENUS REMOVAL
+
 
 /**
  * If we are not satisfied, this will be ran through
@@ -53,7 +54,7 @@
 	//the message that will be sent to the owner at the end
 	var/lust_message = "Your breath begins to feel warm..."
 	//we are using if statements so that it slowly becomes more and more to the person
-	human_owner.manual_emote(pick(lust_emotes))
+	//human_owner.manual_emote(pick(lust_emotes)) VENUS REMOVAL
 	if(stress >= 60)
 		//human_owner.set_jitter_if_lower(40 SECONDS) VENUS REMOVAL
 		lust_message = "You feel a static sensation all across your skin..."
@@ -139,20 +140,20 @@
 		return TRUE
 	return FALSE
 
-/datum/brain_trauma/very_special/bimbo/handle_speech(datum/source, list/speech_args)
-	if(!HAS_TRAIT(owner, TRAIT_BIMBO)) //You have the trauma but not the trait, go ahead and fail here
-		return ..()
-	var/message = speech_args[SPEECH_MESSAGE]
-	var/list/split_message = splittext(message, " ") //List each word in the message
-	for (var/i in 1 to length(split_message))
-		if(findtext(split_message[i], "*") || findtext(split_message[i], ";") || findtext(split_message[i], ":"))
-			continue
-		if(prob(10))
-			var/insert_muffle = pick("... Mmmph...", "... Hmmphh...", "... Gmmmh...", "... Fmmmmph...")
-			split_message[i] = split_message[i] + insert_muffle
+///datum/brain_trauma/very_special/bimbo/handle_speech(datum/source, list/speech_args) VENUS REMOVAL: No text splitting
+	//if(!HAS_TRAIT(owner, TRAIT_BIMBO)) //You have the trauma but not the trait, go ahead and fail here VENUS REMOVAL
+		//return ..() VENUS REMOVAL
+	//var/message = speech_args[SPEECH_MESSAGE] VENUS REMOVAL
+	//var/list/split_message = splittext(message, " ") //List each word in the message VENUS REMOVAL
+	//for (var/i in 1 to length(split_message)) VENUS REMOVAL
+		//if(findtext(split_message[i], "*") || findtext(split_message[i], ";") || findtext(split_message[i], ":")) VENUS REMOVAL
+			//continue VENUS REMOVAL
+		//if(prob(10)) VENUS REMOVAL
+			//var/insert_muffle = pick("... Mmmph...", "... Hmmphh...", "... Gmmmh...", "... Fmmmmph...") VENUS REMOVAL
+			//split_message[i] = split_message[i] + insert_muffle VENUS REMOVAL
 
-	message = jointext(split_message, " ")
-	speech_args[SPEECH_MESSAGE] = message
+	//message = jointext(split_message, " ") VENUS REMOVAL
+	//speech_args[SPEECH_MESSAGE] = message VENUS REMOVAL
 
 /datum/brain_trauma/very_special/bimbo/on_gain()
 	. = ..()

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -141,10 +141,10 @@
 	return FALSE
 /* VENUS REMOVAL: No text splitting
 /datum/brain_trauma/very_special/bimbo/handle_speech(datum/source, list/speech_args)
-	if(!HAS_TRAIT(owner, TRAIT_BIMBO))
+	if(!HAS_TRAIT(owner, TRAIT_BIMBO)) //You have the trauma but not the trait, go ahead and fail here
 		return ..()
 	var/message = speech_args[SPEECH_MESSAGE]
-	var/list/split_message = splittext(message, " ")
+	var/list/split_message = splittext(message, " ") //List each word in the message
 	for (var/i in 1 to length(split_message))
 		if(findtext(split_message[i], "*") || findtext(split_message[i], ";") || findtext(split_message[i], ":"))
 			continue

--- a/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
+++ b/modular_skyrat/modules/modular_items/lewd_items/code/lewd_quirks.dm
@@ -33,15 +33,15 @@
 	///The time between each desire message within company
 	var/desire_cooldown_number = 30 SECONDS
 	///The list of manual emotes that will be done when unsatisfied
-	//var/static/list/lust_emotes = list( VENUS REMOVAL: Removes emote spam
-		//"pants as their body trembles lightly.", VENUS REMOVAL
-		//"lightly touches themselves up and down, feeling every inch.", VENUS REMOVAL
-		//"puts their finger in their mouth and slightly bites down.", VENUS REMOVAL
-		//"places their hands on their hip as they slowly gyrate.", VENUS REMOVAL
-		//"moans, their head tilted slightly." VENUS REMOVAL
-	//) VENUS REMOVAL
-
-
+/* VENUS REMOVAL: No emote spam. Shoo
+	var/static/list/lust_emotes = list(
+		"pants as their body trembles lightly.",
+		"lightly touches themselves up and down, feeling every inch.",
+		"puts their finger in their mouth and slightly bites down.",
+		"places their hands on their hip as they slowly gyrate.",
+		"moans, their head tilted slightly."
+	)
+*/
 /**
  * If we are not satisfied, this will be ran through
  */
@@ -139,22 +139,22 @@
 			continue
 		return TRUE
 	return FALSE
+/* VENUS REMOVAL: No text splitting
+/datum/brain_trauma/very_special/bimbo/handle_speech(datum/source, list/speech_args)
+	if(!HAS_TRAIT(owner, TRAIT_BIMBO))
+		return ..()
+	var/message = speech_args[SPEECH_MESSAGE]
+	var/list/split_message = splittext(message, " ")
+	for (var/i in 1 to length(split_message))
+		if(findtext(split_message[i], "*") || findtext(split_message[i], ";") || findtext(split_message[i], ":"))
+			continue
+		if(prob(10))
+			var/insert_muffle = pick("... Mmmph...", "... Hmmphh...", "... Gmmmh...", "... Fmmmmph...")
+			split_message[i] = split_message[i] + insert_muffle
 
-///datum/brain_trauma/very_special/bimbo/handle_speech(datum/source, list/speech_args) VENUS REMOVAL: No text splitting
-	//if(!HAS_TRAIT(owner, TRAIT_BIMBO)) //You have the trauma but not the trait, go ahead and fail here VENUS REMOVAL
-		//return ..() VENUS REMOVAL
-	//var/message = speech_args[SPEECH_MESSAGE] VENUS REMOVAL
-	//var/list/split_message = splittext(message, " ") //List each word in the message VENUS REMOVAL
-	//for (var/i in 1 to length(split_message)) VENUS REMOVAL
-		//if(findtext(split_message[i], "*") || findtext(split_message[i], ";") || findtext(split_message[i], ":")) VENUS REMOVAL
-			//continue VENUS REMOVAL
-		//if(prob(10)) VENUS REMOVAL
-			//var/insert_muffle = pick("... Mmmph...", "... Hmmphh...", "... Gmmmh...", "... Fmmmmph...") VENUS REMOVAL
-			//split_message[i] = split_message[i] + insert_muffle VENUS REMOVAL
-
-	//message = jointext(split_message, " ") VENUS REMOVAL
-	//speech_args[SPEECH_MESSAGE] = message VENUS REMOVAL
-
+	message = jointext(split_message, " ")
+	speech_args[SPEECH_MESSAGE] = message
+*/
 /datum/brain_trauma/very_special/bimbo/on_gain()
 	. = ..()
 	owner.add_mood_event("bimbo", /datum/mood_event/bimbo)

--- a/modular_zzplurt/code/modules/lewd/interaction_menu/interactions/lewd/fuck.dm
+++ b/modular_zzplurt/code/modules/lewd/interaction_menu/interactions/lewd/fuck.dm
@@ -247,8 +247,8 @@
 	if(HAS_TRAIT(target, TRAIT_BIMBO))												//Checks if the person being penetrated is a bimbo
 		target.adjustStaminaLoss(40)												//Applies 40 stamina damage to the target being penetrated
 		if(SPT_PROB(10, 2.5))
-			to_chat(target, span_purple("You feel so helpless..."))						//Bimbo vulnerability chat message
+			to_chat(target, span_purple("You feel so helpless..."))					//Bimbo vulnerability chat message
 		if(target.getStaminaLoss() >= 100)											//Checks if stamina damage is greater or equal to 100
 			target.Stun(120)														//Once in stamina crit, you're stunlocked for intercourse
 			if(SPT_PROB(10, 2.5))
-				to_chat(target, span_purple("It feels too good..."))					//VENUS ADDITION END
+				to_chat(target, span_purple("It feels too good..."))				//VENUS ADDITION END

--- a/modular_zzplurt/code/modules/lewd/interaction_menu/interactions/lewd/fuck.dm
+++ b/modular_zzplurt/code/modules/lewd/interaction_menu/interactions/lewd/fuck.dm
@@ -238,17 +238,14 @@
 	target_arousal = 8
 	target_pain = 4
 
-/*
-*	VENUS: BIMBO vulnerability
-*/
-
+//VENUS ADDITION START: Vulnerability to penetration
 /datum/interaction/lewd/fuck/post_interaction(mob/living/user, mob/living/target)	//VENUS ADDITION START: Bimbo vulnerability to penetration
 	. = ..()
 	if(HAS_TRAIT(target, TRAIT_BIMBO))												//Checks if the person being penetrated is a bimbo
-		target.adjustStaminaLoss(40)												//Applies 40 stamina damage to the target being penetrated
-		if(SPT_PROB(10, 2.5))
+		target.adjustStaminaLoss(30)												//Applies 20 stamina damage to the target being penetrated
+		if(prob(15))
 			to_chat(target, span_purple("You feel so helpless..."))					//Bimbo vulnerability chat message
-		if(target.getStaminaLoss() >= 100)											//Checks if stamina damage is greater or equal to 100
-			target.Stun(120)														//Once in stamina crit, you're stunlocked for intercourse
-			if(SPT_PROB(10, 2.5))
+		if(target.has_status_effect(/datum/status_effect/incapacitating/stamcrit))	//Checks if target is in stamina critical state
+			if(prob(15))
 				to_chat(target, span_purple("It feels too good..."))				//VENUS ADDITION END
+//VENUS ADDITION END

--- a/modular_zzplurt/code/modules/lewd/interaction_menu/interactions/lewd/fuck.dm
+++ b/modular_zzplurt/code/modules/lewd/interaction_menu/interactions/lewd/fuck.dm
@@ -239,13 +239,13 @@
 	target_pain = 4
 
 //VENUS ADDITION START: Vulnerability to penetration
-/datum/interaction/lewd/fuck/post_interaction(mob/living/user, mob/living/target)	//VENUS ADDITION START: Bimbo vulnerability to penetration
+/datum/interaction/lewd/fuck/post_interaction(mob/living/user, mob/living/target)
 	. = ..()
-	if(HAS_TRAIT(target, TRAIT_BIMBO))												//Checks if the person being penetrated is a bimbo
-		target.adjustStaminaLoss(30)												//Applies 20 stamina damage to the target being penetrated
+	if(HAS_TRAIT(target, TRAIT_BIMBO))
+		target.adjustStaminaLoss(30)
 		if(prob(15))
-			to_chat(target, span_purple("You feel so helpless..."))					//Bimbo vulnerability chat message
-		if(target.has_status_effect(/datum/status_effect/incapacitating/stamcrit))	//Checks if target is in stamina critical state
+			to_chat(target, span_purple("You feel so helpless..."))
+		if(target.has_status_effect(/datum/status_effect/incapacitating/stamcrit))
 			if(prob(15))
-				to_chat(target, span_purple("It feels too good..."))				//VENUS ADDITION END
+				to_chat(target, span_purple("It feels too good..."))
 //VENUS ADDITION END

--- a/modular_zzplurt/code/modules/lewd/interaction_menu/interactions/lewd/fuck.dm
+++ b/modular_zzplurt/code/modules/lewd/interaction_menu/interactions/lewd/fuck.dm
@@ -237,3 +237,16 @@
 	user_arousal = 8
 	target_arousal = 8
 	target_pain = 4
+
+/*
+*	VENUS: BIMBO vulnerability
+*/
+
+/datum/interaction/lewd/fuck/post_interaction(mob/living/user, mob/living/target)	//VENUS ADDITION: Bimbo vulnerability to penetration
+	. = ..()																		//VENUS ADDITION
+	if(HAS_TRAIT(target, TRAIT_BIMBO))												//VENUS ADDITION: Checks if the person being penetrated is a bimbo
+		target.adjustStaminaLoss(40)												//VENUS ADDITION: Applies 40 stamina damage to the target being penetrated
+		to_chat(target, span_purple("You feel so helpless..."))						//VENUS ADDITION: Bimbo vulnerability chat message
+		if(target.getStaminaLoss() >= 100)											//VENUS ADDITION: Checks if stamina damage is greater or equal to 100
+			target.Stun(120)														//VENUS ADDITION: Once in stamina crit, you're stunlocked for intercourse
+			to_chat(target, span_purple("It feels too good..."))					//VENUS ADDITION: Bimbo vulnerability chat message

--- a/modular_zzplurt/code/modules/lewd/interaction_menu/interactions/lewd/fuck.dm
+++ b/modular_zzplurt/code/modules/lewd/interaction_menu/interactions/lewd/fuck.dm
@@ -242,11 +242,13 @@
 *	VENUS: BIMBO vulnerability
 */
 
-/datum/interaction/lewd/fuck/post_interaction(mob/living/user, mob/living/target)	//VENUS ADDITION: Bimbo vulnerability to penetration
-	. = ..()																		//VENUS ADDITION
-	if(HAS_TRAIT(target, TRAIT_BIMBO))												//VENUS ADDITION: Checks if the person being penetrated is a bimbo
-		target.adjustStaminaLoss(40)												//VENUS ADDITION: Applies 40 stamina damage to the target being penetrated
-		to_chat(target, span_purple("You feel so helpless..."))						//VENUS ADDITION: Bimbo vulnerability chat message
-		if(target.getStaminaLoss() >= 100)											//VENUS ADDITION: Checks if stamina damage is greater or equal to 100
-			target.Stun(120)														//VENUS ADDITION: Once in stamina crit, you're stunlocked for intercourse
-			to_chat(target, span_purple("It feels too good..."))					//VENUS ADDITION: Bimbo vulnerability chat message
+/datum/interaction/lewd/fuck/post_interaction(mob/living/user, mob/living/target)	//VENUS ADDITION START: Bimbo vulnerability to penetration
+	. = ..()
+	if(HAS_TRAIT(target, TRAIT_BIMBO))												//Checks if the person being penetrated is a bimbo
+		target.adjustStaminaLoss(40)												//Applies 40 stamina damage to the target being penetrated
+		if(SPT_PROB(10, 2.5))
+			to_chat(target, span_purple("You feel so helpless..."))						//Bimbo vulnerability chat message
+		if(target.getStaminaLoss() >= 100)											//Checks if stamina damage is greater or equal to 100
+			target.Stun(120)														//Once in stamina crit, you're stunlocked for intercourse
+			if(SPT_PROB(10, 2.5))
+				to_chat(target, span_purple("It feels too good..."))					//VENUS ADDITION END


### PR DESCRIPTION

## About The Pull Request
Adds penetration vulnerability, such as stamina damage and being stunned, to anyone with TRAIT_BIMBO
## Why It's Good For The Game
Currently the bimbo trait spams emotes, fills your chat with horny messages, and makes you suffocate. It's not very interesting as a trait, and since it was added, not many people engage with the bimbo trait and bimboification.

The trait's mood description is, " So-o... Help..less... Lo-ve it! ", so I've decided the trait makes you truly helpless.

When a bimbo is penetrated, they take stamina damage, eventually becoming pinned to the floor until intercourse stops. This trait makes you **incredibly** vulnerable to penetration.

This is meant to simulate "fucked silly".

---

* Bimbos no longer spam emotes, except the moan emote. Bimbos can moan as a treat.
* Bimbos no longer stutter when forming sentences because it's annoying for roleplay, and people usually add their own huffs, stutters, etc. It's not needed.
* Bimbos now take stamina damage when being penetrated.

## Changelog
:cl:
add: Adds Bimbo Vulnerability. Bimbos now take stamina damage when penetrated, resulting in them being pinned to the floor. Bimbos can now form complex sentences for a better roleplay experience and will no longer emote spam (because it annoys people).
/:cl:
