### PR TITLE
Fixes legion crates being immediatelly destroyed upon spawning

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -168,7 +168,8 @@
 		loot = list(/obj/item/storm_staff)
 		elimination = FALSE
 	else if(prob(20)) //20% chance for sick lootz.
-		loot = list(/obj/structure/closet/crate/necropolis/tendril)
+//		loot = list(/obj/structure/closet/crate/necropolis/tendril) // VENUS EDIT OLD
+		loot = list(/obj/structure/closet/crate/necropolis/tendril/legion) // VENUS EDIT NEW
 		if(!true_spawn)
 			loot = null
 	return ..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -168,8 +168,7 @@
 		loot = list(/obj/item/storm_staff)
 		elimination = FALSE
 	else if(prob(20)) //20% chance for sick lootz.
-//		loot = list(/obj/structure/closet/crate/necropolis/tendril) // VENUS EDIT OLD
-		loot = list(/obj/structure/closet/crate/necropolis/tendril/legion) // VENUS EDIT NEW
+		loot = list(/obj/structure/closet/crate/necropolis/tendril/legion) // VENUS EDIT (Fixes loot being broken by legion) - Original: /obj/structure/closet/crate/necropolis/tendril
 		if(!true_spawn)
 			loot = null
 	return ..()

--- a/modular_zzvenus/code/modules/mining/code/legion_chest.dm
+++ b/modular_zzvenus/code/modules/mining/code/legion_chest.dm
@@ -1,0 +1,23 @@
+// The legion has a nasty habit of destroying its own chests, so these ones are non-dense until moved
+/obj/structure/closet/crate/necropolis/tendril/legion
+	name = "transparent necropolis chest"
+	desc = "It's watching you suspiciously. You need a skeleton key to open it. Looks you can move through it."
+	density = FALSE
+	alpha = 150
+
+/obj/structure/closet/crate/necropolis/tendril/legion/Initialize(mapload)
+	. = ..()
+	RegisterSignal(src, COMSIG_MOVABLE_MOVED, PROC_REF(on_moved))
+
+/obj/structure/closet/crate/necropolis/tendril/legion/Destroy(force)
+	if(!density)
+		UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
+	return ..()
+
+/obj/structure/closet/crate/necropolis/tendril/legion/proc/on_moved()
+	SIGNAL_HANDLER
+	UnregisterSignal(src, COMSIG_MOVABLE_MOVED)
+	name = "necropolis chest"
+	desc = "It's watching you suspiciously. You need a skeleton key to open it."
+	density = TRUE
+	animate(src, time = 3 SECONDS, alpha = 255)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -10326,6 +10326,7 @@
 #include "modular_zzvenus\code\modules\events\cognomerge.dm"
 #include "modular_zzvenus\code\modules\events\portal_storm.dm"
 #include "modular_zzvenus\code\modules\experisci\experiment\experiments.dm"
+#include "modular_zzvenus\code\modules\mining\code\legion_chest.dm"
 #include "modular_zzvenus\code\modules\mob\emotes.dm"
 #include "modular_zzvenus\code\modules\mob\living\stats.dm"
 #include "modular_zzvenus\code\modules\research\quantum_parts.dm"


### PR DESCRIPTION

## About The Pull Request

Makes the crates legion drops non-dense until they are moved preventing the legion from immediatelly destroying them.

## Why It's Good For The Game

Because this is one of 2 loot items the legion drops, it in fact very often destroys them turning them into literal sheets of metal

## Proof Of Testing

https://github.com/user-attachments/assets/5f92a52a-4890-45f5-bd42-699c968aac71

## Changelog

:cl:
fix: The legion megafauna now drops non-dense necropolis chests until you touch them, to avoid the legion breaking them
/:cl:
