### PR TITLE
Increasing max cap of custom shuttle size.

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -605,7 +605,7 @@ RANDOM_LOOT_WEIGHT_MODIFIER 1
 
 ## Custom shuttle spam prevention. Changine these numbers allows you to change the maxsize and amount of custom shuttles.
 MAX_SHUTTLE_COUNT 6
-MAX_SHUTTLE_SIZE 300
+MAX_SHUTTLE_SIZE 650
 
 ### Spy config
 ## Changes refresh period between bounties - in deciseconds


### PR DESCRIPTION

## About The Pull Request
 
Increasing maximum tile cap of custom shuttle from 300 to 650 tiles.

## Why It's Good For The Game

Bigger cap lets people construct more cool and good looking custom shuttles.

## Proof Of Testing

Please dont mind video quality because I compressed it so it would be under 10mb size cap.

https://github.com/user-attachments/assets/531b2fad-e3f7-48b8-bcbd-0468507f6338

## Changelog
:cl:
balance: max_shuttle_size 300 > 650
/:cl:
